### PR TITLE
Use new class name in python init

### DIFF
--- a/python/__init__.py
+++ b/python/__init__.py
@@ -31,5 +31,5 @@ except ImportError:
 	pass
 
 # import any pure python here
-from .trunked_radio import trunked_radio
-#
+from .trunked_radio import trunked_radio_hier
+


### PR DESCRIPTION
This resolves the module import for the trunked_radio_hier class for GNU Radio.

I'm determined to get this thing working (though I'm not sure I quite have the chops to do it...); yours is the closest thing I've found to making this work.  Maybe if I stare at the code long enough I'll figure something out :)